### PR TITLE
feat: add mp2ts-extract tool for elementary stream extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New `mp2ts-extract` tool to extract elementary video streams from TS files
+  - Automatically waits for parameter sets (VPS/SPS/PPS) before extraction
+  - Supports both AVC and HEVC streams
+  - Can extract specific PID or auto-select first video stream
 - Picture type (I, P, B) information for HEVC streams in mp2ts-nallister
 - `-waitps` option to mp2ts-nallister to wait for parameter sets before printing NAL units
 - SMPTE-2038 data option to mp2ts-tools

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@
 all: test check coverage build
 
 .PHONY: build
-build: mp2ts-info mp2ts-nallister mp2ts-pslister
+build: mp2ts-info mp2ts-nallister mp2ts-pslister mp2ts-extract
 
 .PHONY: prepare
 prepare:
 	go mod tidy
 
-mp2ts-info mp2ts-nallister mp2ts-pslister:
+mp2ts-info mp2ts-nallister mp2ts-pslister mp2ts-extract:
 	go build -ldflags "-X github.com/Eyevinn/mp2ts-tools/internal.commitVersion=$$(git describe --tags HEAD) -X github.com/Eyevinn/mp2ts-tools/internal.commitDate=$$(git log -1 --format=%ct)" -o out/$@ ./cmd/$@/main.go
 
 .PHONY: test

--- a/cmd/mp2ts-extract/main.go
+++ b/cmd/mp2ts-extract/main.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/Eyevinn/mp2ts-tools/internal"
+)
+
+var usg = `Usage of %s:
+
+%s extracts elementary video streams (PES payloads) from MPEG-2 Transport Stream files.
+By default, it waits for parameter sets (VPS/SPS/PPS) before starting extraction.
+`
+
+func parseOptions() internal.Options {
+	opts := internal.Options{ShowStreamInfo: true, Indent: false, WaitForPS: true}
+	flag.IntVar(&opts.ExtractPID, "pid", 0, "PID to extract (if 0, extract first video PID found)")
+	flag.StringVar(&opts.OutPutTo, "output", "", "output file path (- for stdout, required)")
+	flag.BoolVar(&opts.WaitForPS, "waitps", true, "wait for parameter sets (VPS/SPS/PPS) before extraction")
+	flag.BoolVar(&opts.Version, "version", false, "print version")
+
+	flag.Usage = func() {
+		parts := strings.Split(os.Args[0], "/")
+		name := parts[len(parts)-1]
+		fmt.Fprintf(os.Stderr, usg, name, name)
+		fmt.Fprintf(os.Stderr, "\nRun as: %s [options] file.ts (- for stdin) with options:\n\n", name)
+		flag.PrintDefaults()
+	}
+
+	flag.Parse()
+	return opts
+}
+
+func extract(ctx context.Context, w io.Writer, f io.Reader, o internal.Options) error {
+	if o.OutPutTo == "" {
+		return fmt.Errorf("output file path is required (use -output)")
+	}
+
+	outPutToFile := o.OutPutTo != "-"
+	var textOutput io.Writer
+	var esOutput io.Writer
+
+	// If we output to file, print info to stdout
+	if outPutToFile {
+		// Remove existing output file
+		if err := internal.RemoveFileIfExists(o.OutPutTo); err != nil {
+			return err
+		}
+		file, err := internal.OpenFileAndAppend(o.OutPutTo)
+		if err != nil {
+			return err
+		}
+		esOutput = file
+		textOutput = w
+		defer file.Close()
+	} else { // If we output to stdout, print info to stderr
+		esOutput = w
+		textOutput = os.Stderr
+	}
+
+	return internal.ExtractES(ctx, textOutput, esOutput, f, o)
+}
+
+func main() {
+	o, inFile := internal.ParseParams(parseOptions)
+	err := internal.Execute(os.Stdout, o, inFile, extract)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/internal/extract.go
+++ b/internal/extract.go
@@ -1,0 +1,151 @@
+package internal
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/Eyevinn/mp4ff/avc"
+	"github.com/Eyevinn/mp4ff/hevc"
+	"github.com/asticode/go-astits"
+)
+
+// ExtractES extracts elementary stream from a TS file
+func ExtractES(ctx context.Context, textWriter io.Writer, esWriter io.Writer, f io.Reader, o Options) error {
+	rd := bufio.NewReaderSize(f, 1000*PacketSize)
+	dmx := astits.NewDemuxer(ctx, rd)
+	pmtPID := -1
+	esKinds := make(map[uint16]string)
+	targetPID := uint16(0)
+	extracting := false
+	hasAVCPS := false
+	hasHEVCPS := false
+	jp := &JsonPrinter{W: textWriter, Indent: o.Indent}
+
+dataLoop:
+	for {
+		// Check if context was cancelled
+		select {
+		case <-ctx.Done():
+			break dataLoop
+		default:
+		}
+
+		d, err := dmx.NextData()
+		if err != nil {
+			if err.Error() == "astits: no more packets" {
+				break dataLoop
+			}
+			return fmt.Errorf("reading next data %w", err)
+		}
+
+		// Print PID information
+		if pmtPID < 0 && d.PMT != nil {
+			// Loop through elementary streams
+			for _, es := range d.PMT.ElementaryStreams {
+				streamInfo := ParseAstitsElementaryStreamInfo(es)
+				if streamInfo != nil {
+					esKinds[es.ElementaryPID] = streamInfo.Codec
+					jp.Print(streamInfo, o.ShowStreamInfo)
+
+					// Select target PID
+					if targetPID == 0 && (streamInfo.Codec == "AVC" || streamInfo.Codec == "HEVC") {
+						if o.ExtractPID == 0 {
+							// Auto-select first video PID
+							targetPID = es.ElementaryPID
+						} else if int(es.ElementaryPID) == o.ExtractPID {
+							// User-specified PID
+							targetPID = es.ElementaryPID
+						}
+					}
+				}
+			}
+			pmtPID = int(d.PID)
+
+			if targetPID == 0 {
+				if o.ExtractPID == 0 {
+					return fmt.Errorf("no video PID found in stream")
+				}
+				return fmt.Errorf("specified PID %d not found or not a video stream", o.ExtractPID)
+			}
+		}
+
+		if pmtPID == -1 {
+			continue
+		}
+
+		pes := d.PES
+		if pes == nil || d.PID != targetPID {
+			continue
+		}
+
+		codec := esKinds[d.PID]
+		data := pes.Data
+
+		// Check for parameter sets based on codec
+		switch codec {
+		case "AVC":
+			if o.WaitForPS && !hasAVCPS {
+				// Check if this PES contains SPS and PPS
+				nalus := avc.ExtractNalusFromByteStream(data)
+				hasSPS := false
+				hasPPS := false
+				for _, nalu := range nalus {
+					naluType := avc.GetNaluType(nalu[0])
+					if naluType == avc.NALU_SPS {
+						hasSPS = true
+					} else if naluType == avc.NALU_PPS {
+						hasPPS = true
+					}
+				}
+				if hasSPS && hasPPS {
+					hasAVCPS = true
+					extracting = true
+				}
+			} else if !o.WaitForPS {
+				extracting = true
+			}
+
+		case "HEVC":
+			if o.WaitForPS && !hasHEVCPS {
+				// Check if this PES contains SPS and PPS (and optionally VPS)
+				nalus := avc.ExtractNalusFromByteStream(data)
+				hasSPS := false
+				hasPPS := false
+				for _, nalu := range nalus {
+					naluType := hevc.GetNaluType(nalu[0])
+					if naluType == hevc.NALU_SPS {
+						hasSPS = true
+					} else if naluType == hevc.NALU_PPS {
+						hasPPS = true
+					}
+				}
+				if hasSPS && hasPPS {
+					hasHEVCPS = true
+					extracting = true
+				}
+			} else if !o.WaitForPS {
+				extracting = true
+			}
+
+		default:
+			// For non-video codecs, start extracting immediately
+			extracting = true
+		}
+
+		// Write PES payload to output if we're extracting
+		if extracting {
+			_, err := esWriter.Write(data)
+			if err != nil {
+				return fmt.Errorf("writing elementary stream data: %w", err)
+			}
+		}
+	}
+
+	if !extracting {
+		return fmt.Errorf("no parameter sets found in stream, extraction did not start")
+	}
+
+	return jp.Error()
+}

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -38,6 +38,7 @@ type Options struct {
 	PidsToDrop     string
 	OutPutTo       string
 	WaitForPS      bool // Wait for parameter sets (SPS/PPS) before printing NAL units
+	ExtractPID     int  // PID to extract for elementary stream extraction (0 = first video PID)
 }
 
 func CreateFullOptions(max int) Options {


### PR DESCRIPTION
Add new mp2ts-extract command-line tool that extracts elementary video streams (PES payloads) from MPEG-2 Transport Stream files.

Features:
- Automatically waits for parameter sets (VPS/SPS/PPS) before extraction by default
- Supports both AVC (H.264) and HEVC (H.265) video streams
- Can extract specific PID or auto-select first video stream
- Outputs raw byte stream in Annex B format
- Optional -waitps flag to control parameter set waiting behavior

This is useful for extracting raw video elementary streams for analysis, transcoding, or playback with tools that expect Annex B byte streams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)