### PR TITLE
docs: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Nothing yet
+
+## [0.3.0] - 2025-10-14
+
 ### Added
 
 - New `mp2ts-extract` tool to extract elementary video streams from TS files
@@ -47,7 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - initial version of the repo
 - ts-info tool
 
-[Unreleased]: https://github.com/Eyevinn/mp2ts-tools/releases/tag/v0.2.1...HEAD
+[Unreleased]: https://github.com/Eyevinn/mp2ts-tools/releases/tag/v0.3.0...HEAD
+[0.3.0]: https://github.com/Eyevinn/mp2ts-tools/releases/tag/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/Eyevinn/mp2ts-tools/releases/tag/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Eyevinn/mp2ts-tools/releases/tag/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Eyevinn/mp2ts-tools/releases/tag/v0.1.0

--- a/internal/version.go
+++ b/internal/version.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	commitVersion string = "v0.2.1"     // May be updated using build flags
-	commitDate    string = "1706176128" // commitDate in Epoch seconds (may be overridden using build flags)
+	commitVersion string = "v0.3.0"     // May be updated using build flags
+	commitDate    string = "1760474121" // commitDate in Epoch seconds (may be overridden using build flags)
 )
 
 // GetVersion - get version and also commitHash and commitDate if inserted via Makefile


### PR DESCRIPTION
### Added

- New `mp2ts-extract` tool to extract elementary video streams from TS files
  - Automatically waits for parameter sets (VPS/SPS/PPS) before extraction
  - Supports both AVC and HEVC streams
  - Can extract specific PID or auto-select first video stream
- Picture type (I, P, B) information for HEVC streams in mp2ts-nallister
- `-waitps` option to mp2ts-nallister to wait for parameter sets before printing NAL units
- SMPTE-2038 data option to mp2ts-tools