### PR TITLE
Deduplicate parameter set output and improve PicTiming SEI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet
+### Changed
+
+- mp2ts-pslister now always shows verbose parameter set info (removed `-ps` flag)
+- Parameter sets (SPS/PPS/VPS) are only printed when they change, avoiding duplicate output for AVC and HEVC
+- AVC PicTiming SEI output now includes all clock timestamp fields (ct_type, counting_type, n_frames, time, time_offset, etc.)
 
 ## [0.3.0] - 2025-10-14
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+A collection of Go CLI tools for analyzing and manipulating MPEG-2 Transport Stream (TS) files. Each tool lives under `cmd/mp2ts-<name>/` and shares core logic from the `internal/` package.
+
+## Build and Development Commands
+
+```bash
+# Build all tools (outputs to out/)
+make build
+
+# Run all tests
+go test ./...
+
+# Update golden files after intentional output changes
+go test ./internal/... -update
+
+# Lint (requires golangci-lint)
+golangci-lint run
+
+# Tidy dependencies
+go mod tidy
+```
+
+Build injects version info via `-ldflags -X` — the Makefile sets `internal.commitVersion` and `internal.commitDate` at link time from git tags/timestamps.
+
+## Architecture
+
+### internal/ — All core logic
+
+There is no `pkg/` directory. All shared code lives in `internal/`.
+
+**Key types:**
+- `Options` (`utils.go`) — Configuration struct used by all tools. Each tool's `parseOptions()` sets tool-specific defaults and wires up `flag` parsing.
+- `JsonPrinter` (`printer.go`) — Conditional JSON output writer. Methods like `Print(data, show bool)` only emit when `show` is true.
+- `AvcPS` / `HevcPS` (`avc.go`, `hevc.go`) — Parameter set state machines that track SPS/PPS/VPS, detect changes via hex comparison, and avoid redundant output.
+- `NaluFrameData` (`nalu.go`) — Per-frame output: PID, PTS/DTS, frame type (I/P/B), NAL unit details.
+- `StreamStatistics` (`statistics.go`) — Frame rate and GoP duration calculated from timestamp steps.
+
+**Main parse functions in `parser.go`:**
+- `ParseAll()` — Full analysis: stream info, parameter sets, NAL units, SEI, statistics
+- `ParseInfo()` — Quick PMT/stream metadata only (used by mp2ts-info)
+- `ParseSCTE35()` — Ad insertion splice commands (uses gots, not astits)
+- `FilterPids()` — Drop specified PIDs, rewrite PAT/PMT
+
+**Other entry points:**
+- `ExtractES()` (`extract.go`) — Elementary stream extraction to Annex B format
+
+**Two TS libraries used for different purposes:**
+- `go-astits` — High-level demuxing (PAT/PMT/PES extraction). Used by most tools.
+- `gots/v2` — Low-level packet manipulation. Used by SCTE-35 parsing and PID filtering.
+
+**Timestamp handling (`const.go`):**
+- 90kHz timescale (`TimeScale = 90000`), 33-bit PTS wrap (`PtsWrap = 1 << 33`)
+- `SignedPTSDiff()` / `UnsignedPTSDiff()` handle wraparound
+
+### cmd/ — CLI tools
+
+Every tool follows the same 3-function pattern in `main.go`:
+1. `parseOptions()` — Returns `internal.Options` with tool-specific flag defaults
+2. A parse function — Calls the appropriate `internal.Parse*()` function
+3. `main()` — Calls `internal.ParseParams(parseOptions)` then `internal.Execute(os.Stdout, o, inFile, parseFn)`. Execute handles context/SIGINT, file open/close, and error reporting.
+
+Tools: `mp2ts-info`, `mp2ts-nallister`, `mp2ts-pslister`, `mp2ts-extract`, `mp2ts-timeshift`, `mp2ts-pidfilter`, `mp2ts-prepare`.
+
+### Testing
+
+Golden file tests in `internal/parser_test.go`. Test cases run various `Options` configurations against `.ts` files in `internal/testdata/` and compare output to `internal/testdata/golden_*.txt`.
+
+- Run `go test ./internal/... -update` to regenerate golden files after intentional output changes
+- Golden files normalize `\r\n` to `\n` for cross-platform compatibility
+
+## Conventions
+
+- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) (e.g., `feat:`, `fix:`, `docs:`, `chore:`)
+- Manual [CHANGELOG.md](CHANGELOG.md) tracks releases

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ mp2ts-info video.ts
 `mp2ts-nallister` shows detailed information about NAL units including:
 - PTS/DTS timestamps
 - Picture types (I, P, B frames) for both AVC and HEVC
-- PicTiming SEI messages
+- PicTiming SEI messages with detailed clock timestamp fields
 - RAI (Random Access Indicator) markers
 - SMPTE-2038 ancillary data
 
@@ -44,7 +44,7 @@ mp2ts-nallister -waitps -max 10 video.ts
 
 ### mp2ts-pslister
 
-`mp2ts-pslister` shows information about parameter sets (SPS, PPS, and VPS for HEVC) in a TS file. Useful for debugging video codec configurations.
+`mp2ts-pslister` shows verbose information about parameter sets (SPS, PPS, and VPS for HEVC) in a TS file. Only prints parameter sets when they change, avoiding duplicate output for unchanged sets. Useful for debugging video codec configurations.
 
 **Example:**
 ```sh

--- a/cmd/mp2ts-pslister/main.go
+++ b/cmd/mp2ts-pslister/main.go
@@ -18,9 +18,8 @@ var usg = `Usage of %s:
 `
 
 func parseOptions() internal.Options {
-	opts := internal.Options{ShowStreamInfo: true, ShowService: false, ShowPS: true, Indent: true, ShowNALU: false, ShowSEIDetails: false, ShowStatistics: false}
+	opts := internal.Options{ShowStreamInfo: true, ShowService: false, ShowPS: true, VerbosePSInfo: true, Indent: true, ShowNALU: false, ShowSEIDetails: false, ShowStatistics: false}
 	flag.IntVar(&opts.MaxNrPictures, "max", 0, "max nr pictures to parse")
-	flag.BoolVar(&opts.VerbosePSInfo, "ps", false, "show verbose information")
 	flag.BoolVar(&opts.Version, "version", false, "print version")
 
 	flag.Usage = func() {

--- a/internal/avc.go
+++ b/internal/avc.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	"github.com/Eyevinn/mp4ff/avc"
@@ -13,6 +14,8 @@ type AvcPS struct {
 	ppss       map[uint32]*avc.PPS
 	spsnalu    []byte
 	ppsnalus   map[uint32][]byte
+	lastSPSHex string
+	lastPPSHex map[uint32]string
 	Statistics StreamStatistics
 }
 
@@ -36,6 +39,7 @@ func (a *AvcPS) setSPS(nalu []byte) error {
 		a.spss = make(map[uint32]*avc.SPS, 1)
 		a.ppss = make(map[uint32]*avc.PPS, 1)
 		a.ppsnalus = make(map[uint32][]byte)
+		a.lastPPSHex = make(map[uint32]string)
 	}
 	sps, err := avc.ParseSPSNALUnit(nalu, true)
 	if err != nil {
@@ -130,7 +134,7 @@ func ParseAVCPES(jp *JsonPrinter, d *astits.DemuxerData, ps *AvcPS, o Options) (
 					if o.ShowSEIDetails && sps != nil {
 						parts = append(parts, SeiOut{
 							Msg:     t.String(),
-							Payload: pt,
+							Payload: picTimingAvcToOut(pt),
 						})
 					} else {
 						parts = append(parts, SeiOut{Msg: t.String()})
@@ -164,11 +168,19 @@ func ParseAVCPES(jp *JsonPrinter, d *astits.DemuxerData, ps *AvcPS, o Options) (
 		return ps, nil
 	}
 	if firstPS {
-		for nr := range ps.spss {
-			jp.PrintPS(pid, "SPS", nr, ps.spsnalu, ps.spss[nr], o.VerbosePSInfo, o.ShowPS)
+		spsHex := hex.EncodeToString(ps.spsnalu)
+		if spsHex != ps.lastSPSHex {
+			ps.lastSPSHex = spsHex
+			for nr := range ps.spss {
+				jp.PrintPS(pid, "SPS", nr, ps.spsnalu, ps.spss[nr], o.VerbosePSInfo, o.ShowPS)
+			}
 		}
 		for nr := range ps.ppss {
-			jp.PrintPS(pid, "PPS", nr, ps.ppsnalus[nr], ps.ppss[nr], o.VerbosePSInfo, o.ShowPS)
+			ppsHex := hex.EncodeToString(ps.ppsnalus[nr])
+			if ppsHex != ps.lastPPSHex[nr] {
+				ps.lastPPSHex[nr] = ppsHex
+				jp.PrintPS(pid, "PPS", nr, ps.ppsnalus[nr], ps.ppss[nr], o.VerbosePSInfo, o.ShowPS)
+			}
 		}
 	}
 
@@ -179,4 +191,35 @@ func ParseAVCPES(jp *JsonPrinter, d *astits.DemuxerData, ps *AvcPS, o Options) (
 
 	jp.Print(nfd, o.ShowNALU)
 	return ps, jp.Error()
+}
+
+// picTimingAvcToOut converts a PicTimingAvcSEI to a richer output struct
+// that exposes all clock timestamp fields hidden by MarshalJSON.
+func picTimingAvcToOut(pt *sei.PicTimingAvcSEI) PicTimingAvcOut {
+	out := PicTimingAvcOut{
+		PictStruct: pt.PictStruct,
+		Clocks:     make([]ClockTSAvcOut, 0, len(pt.Clocks)),
+	}
+	if pt.CbpDbpDelay != nil {
+		out.CpbRemovalDelay = &pt.CbpDbpDelay.CpbRemovalDelay
+		out.DpbOutputDelay = &pt.CbpDbpDelay.DpbOutputDelay
+	}
+	for _, c := range pt.Clocks {
+		co := ClockTSAvcOut{
+			ClockTimeStampFlag: c.ClockTimeStampFlag,
+		}
+		if c.ClockTimeStampFlag {
+			co.CtType = &c.CtType
+			co.NuitFieldBasedFlag = &c.NuitFieldBasedFlag
+			co.CountingType = &c.CountingType
+			co.FullTimeStampFlag = &c.FullTimeStampFlag
+			co.DiscontinuityFlag = &c.DiscontinuityFlag
+			co.CntDroppedFlag = &c.CntDroppedFlag
+			co.NFrames = &c.NFrames
+			co.Time = fmt.Sprintf("%02d:%02d:%02d:%02d", c.Hours, c.Minutes, c.Seconds, c.NFrames)
+			co.TimeOffset = &c.TimeOffsetValue
+		}
+		out.Clocks = append(out.Clocks, co)
+	}
+	return out
 }

--- a/internal/hevc.go
+++ b/internal/hevc.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	"github.com/Eyevinn/mp4ff/avc"
@@ -15,6 +16,9 @@ type HevcPS struct {
 	vpsnalu    []byte
 	spsnalu    []byte
 	ppsnalus   map[uint32][]byte
+	lastVPSHex string
+	lastSPSHex string
+	lastPPSHex map[uint32]string
 	Statistics StreamStatistics
 }
 
@@ -27,6 +31,7 @@ func (a *HevcPS) setSPS(nalu []byte) error {
 		a.spss = make(map[uint32]*hevc.SPS, 1)
 		a.ppss = make(map[uint32]*hevc.PPS, 1)
 		a.ppsnalus = make(map[uint32][]byte, 1)
+		a.lastPPSHex = make(map[uint32]string)
 	}
 	sps, err := hevc.ParseSPSNALUnit(nalu)
 	if err != nil {
@@ -157,12 +162,24 @@ func ParseHEVCPES(jp *JsonPrinter, d *astits.DemuxerData, ps *HevcPS, o Options)
 	}
 
 	if firstPS {
-		jp.PrintPS(pid, "VPS", 0, ps.vpsnalu, nil, o.VerbosePSInfo, o.ShowPS)
-		for nr := range ps.spss {
-			jp.PrintPS(pid, "SPS", nr, ps.spsnalu, ps.spss[nr], o.VerbosePSInfo, o.ShowPS)
+		vpsHex := hex.EncodeToString(ps.vpsnalu)
+		if vpsHex != ps.lastVPSHex {
+			ps.lastVPSHex = vpsHex
+			jp.PrintPS(pid, "VPS", 0, ps.vpsnalu, nil, o.VerbosePSInfo, o.ShowPS)
+		}
+		spsHex := hex.EncodeToString(ps.spsnalu)
+		if spsHex != ps.lastSPSHex {
+			ps.lastSPSHex = spsHex
+			for nr := range ps.spss {
+				jp.PrintPS(pid, "SPS", nr, ps.spsnalu, ps.spss[nr], o.VerbosePSInfo, o.ShowPS)
+			}
 		}
 		for nr := range ps.ppss {
-			jp.PrintPS(pid, "PPS", nr, ps.ppsnalus[nr], ps.ppss[nr], o.VerbosePSInfo, o.ShowPS)
+			ppsHex := hex.EncodeToString(ps.ppsnalus[nr])
+			if ppsHex != ps.lastPPSHex[nr] {
+				ps.lastPPSHex[nr] = ppsHex
+				jp.PrintPS(pid, "PPS", nr, ps.ppsnalus[nr], ps.ppss[nr], o.VerbosePSInfo, o.ShowPS)
+			}
 		}
 	}
 

--- a/internal/nalu.go
+++ b/internal/nalu.go
@@ -19,3 +19,26 @@ type SeiOut struct {
 	Msg     string `json:"msg"`
 	Payload any    `json:"payload,omitempty"`
 }
+
+// PicTimingAvcOut is a richer representation of PicTimingAvcSEI that exposes all fields
+// including those hidden by the mp4ff ClockTSAvc MarshalJSON.
+type PicTimingAvcOut struct {
+	PictStruct     uint8              `json:"pict_struct"`
+	CpbRemovalDelay *uint             `json:"cpb_removal_delay,omitempty"`
+	DpbOutputDelay  *uint             `json:"dpb_output_delay,omitempty"`
+	Clocks         []ClockTSAvcOut    `json:"clocks"`
+}
+
+// ClockTSAvcOut exposes all fields of a clock timestamp from pic_timing SEI.
+type ClockTSAvcOut struct {
+	ClockTimeStampFlag bool   `json:"clock_timestamp_flag"`
+	CtType             *byte  `json:"ct_type,omitempty"`
+	NuitFieldBasedFlag *bool  `json:"nuit_field_based_flag,omitempty"`
+	CountingType       *byte  `json:"counting_type,omitempty"`
+	FullTimeStampFlag  *bool  `json:"full_timestamp_flag,omitempty"`
+	DiscontinuityFlag  *bool  `json:"discontinuity_flag,omitempty"`
+	CntDroppedFlag     *bool  `json:"cnt_dropped_flag,omitempty"`
+	NFrames            *byte  `json:"n_frames,omitempty"`
+	Time               string `json:"time,omitempty"`
+	TimeOffset         *int   `json:"time_offset,omitempty"`
+}

--- a/internal/testdata/golden_bbb_1s.txt
+++ b/internal/testdata/golden_bbb_1s.txt
@@ -27,8 +27,6 @@
 {"pid":256,"rai":false,"pts":212250,"dts":204750,"imgType":"[B]","nalus":[{"type":"AUD_9","len":2},{"type":"NonIDR_1","len":7371}]}
 {"pid":256,"rai":false,"pts":208500,"dts":208500,"imgType":"[B]","nalus":[{"type":"AUD_9","len":2},{"type":"NonIDR_1","len":3435}]}
 {"pid":256,"rai":false,"pts":216000,"dts":212250,"imgType":"[B]","nalus":[{"type":"AUD_9","len":2},{"type":"NonIDR_1","len":4061}]}
-{"pid":256,"parameterSet":"SPS","nr":0,"hex":"6764001facd9405005bb011000000300100000030300f1831960","length":26}
-{"pid":256,"parameterSet":"PPS","nr":0,"hex":"68ebecb22c","length":5}
 {"pid":256,"rai":true,"pts":223500,"dts":216000,"imgType":"[I]","nalus":[{"type":"AUD_9","len":2},{"type":"SPS_7","len":26},{"type":"PPS_8","len":5},{"type":"IDR_5","len":12975}]}
 {"pid":256,"rai":false,"pts":234750,"dts":219750,"imgType":"[P]","nalus":[{"type":"AUD_9","len":2},{"type":"NonIDR_1","len":24332}]}
 {"streamType":"AVC","pid":256,"frameRate":24,"RAIGoPDuration":1,"IDRGoPDuration":1}

--- a/internal/testdata/golden_bbb_1s_no_nalu(no_sei).txt
+++ b/internal/testdata/golden_bbb_1s_no_nalu(no_sei).txt
@@ -3,6 +3,4 @@
 {"pid":256,"parameterSet":"SPS","nr":0,"hex":"6764001facd9405005bb011000000300100000030300f1831960","length":26}
 {"pid":256,"parameterSet":"PPS","nr":0,"hex":"68ebecb22c","length":5}
 {"SDT":[{"serviceId":1,"descriptors":[{"serviceName":"ts-info","providerName":"Eyevinn Technology"}]}]}
-{"pid":256,"parameterSet":"SPS","nr":0,"hex":"6764001facd9405005bb011000000300100000030300f1831960","length":26}
-{"pid":256,"parameterSet":"PPS","nr":0,"hex":"68ebecb22c","length":5}
 {"streamType":"AVC","pid":256,"frameRate":24,"RAIGoPDuration":1,"IDRGoPDuration":1}

--- a/internal/testdata/golden_obs_hevc_aac.txt
+++ b/internal/testdata/golden_obs_hevc_aac.txt
@@ -33,9 +33,6 @@
 {"pid":256,"rai":false,"pts":82920,"dts":82920,"imgType":"[P]","nalus":[{"type":"AUD_35","len":3},{"type":"NonRAP_Trail_1","len":153}]}
 {"pid":256,"rai":false,"pts":85920,"dts":85920,"imgType":"[P]","nalus":[{"type":"AUD_35","len":3},{"type":"NonRAP_Trail_1","len":471}]}
 {"pid":256,"rai":false,"pts":88920,"dts":88920,"imgType":"[P]","nalus":[{"type":"AUD_35","len":3},{"type":"NonRAP_Trail_1","len":352}]}
-{"pid":256,"parameterSet":"VPS","nr":0,"hex":"40010c01ffff016000000300b00000030000030078170240","length":24}
-{"pid":256,"parameterSet":"SPS","nr":0,"hex":"420101016000000300b00000030000030078a005020171f2e205ee45914bff2e7f13fa9a8080808040","length":41}
-{"pid":256,"parameterSet":"PPS","nr":0,"hex":"4401c072f05324","length":7}
 {"pid":256,"rai":true,"pts":91920,"dts":91920,"imgType":"[I]","nalus":[{"type":"AUD_35","len":3},{"type":"VPS_32","len":24},{"type":"SPS_33","len":41},{"type":"PPS_34","len":7},{"type":"RAP_IDR_20","len":24298}]}
 {"pid":256,"rai":false,"pts":94920,"dts":94920,"imgType":"[P]","nalus":[{"type":"AUD_35","len":3},{"type":"NonRAP_Trail_1","len":402}]}
 {"pid":256,"rai":false,"pts":97920,"dts":97920,"imgType":"[P]","nalus":[{"type":"AUD_35","len":3},{"type":"NonRAP_Trail_1","len":400}]}

--- a/internal/testdata/golden_obs_hevc_aac_no_nalu(no_sei).txt
+++ b/internal/testdata/golden_obs_hevc_aac_no_nalu(no_sei).txt
@@ -3,7 +3,4 @@
 {"pid":256,"parameterSet":"VPS","nr":0,"hex":"40010c01ffff016000000300b00000030000030078170240","length":24}
 {"pid":256,"parameterSet":"SPS","nr":0,"hex":"420101016000000300b00000030000030078a005020171f2e205ee45914bff2e7f13fa9a8080808040","length":41}
 {"pid":256,"parameterSet":"PPS","nr":0,"hex":"4401c072f05324","length":7}
-{"pid":256,"parameterSet":"VPS","nr":0,"hex":"40010c01ffff016000000300b00000030000030078170240","length":24}
-{"pid":256,"parameterSet":"SPS","nr":0,"hex":"420101016000000300b00000030000030078a005020171f2e205ee45914bff2e7f13fa9a8080808040","length":41}
-{"pid":256,"parameterSet":"PPS","nr":0,"hex":"4401c072f05324","length":7}
 {"streamType":"HEVC","pid":256,"frameRate":30,"RAIGoPDuration":1,"IDRGoPDuration":1}


### PR DESCRIPTION
## Summary
- Parameter sets (SPS/PPS/VPS) are now only printed when they actually change, eliminating duplicate output for both AVC and HEVC streams
- mp2ts-pslister always shows verbose parameter set info (removed the `-ps` flag)
- AVC PicTiming SEI output now exposes all clock timestamp fields (ct_type, counting_type, n_frames, time, time_offset, etc.)

Solves #18 

## Test plan
- [x] Golden file tests updated and passing
- [x] Run mp2ts-pslister on a TS file with repeated identical parameter sets and verify no duplicates
- [x] Run mp2ts-nallister with `-sei` on an AVC stream and verify richer PicTiming output